### PR TITLE
Clarify login options

### DIFF
--- a/UCDASearches_Blazor/Components/Pages/Login.razor
+++ b/UCDASearches_Blazor/Components/Pages/Login.razor
@@ -19,7 +19,7 @@
         <EditForm Model="@model" OnValidSubmit="HandleLogin" class="w-100">
             <DataAnnotationsValidator />
             <MudStack Spacing="2">
-                <MudTextField @bind-Value="model.AccountId" Label="Account name or email" Variant="Variant.Outlined"
+                <MudTextField @bind-Value="model.AccountId" Label="Username or email" Variant="Variant.Outlined"
                               Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Badge" Required="true" />
                 <MudTextField @bind-Value="model.Password" Label="Password" Variant="Variant.Outlined"
                               InputType="@(_showPwd ? InputType.Text : InputType.Password)"
@@ -39,6 +39,7 @@
 
         <MudLink Href="#" Class="mt-2">Forgot password?</MudLink>
         <MudLink Href="#">Log in with a device</MudLink>
+        <MudLink Href="#">Log in with a backup code</MudLink>
     </MudStack>
 </MudCard>
 

--- a/UCDASearches_Blazor/Components/Pages/Login.razor
+++ b/UCDASearches_Blazor/Components/Pages/Login.razor
@@ -14,7 +14,7 @@
             <circle cx="72" cy="24" r="12" stroke="#135ea1" stroke-width="8" />
         </svg>
 
-        <MudText Typo="Typo.h6" Class="mt-2">Log in</MudText>
+        <MudText Typo="Typo.h6" Class="mt-2">Log in to Nextcloud</MudText>
 
         <EditForm Model="@model" OnValidSubmit="HandleLogin" class="w-100">
             <DataAnnotationsValidator />


### PR DESCRIPTION
## Summary
- clarify account input label to “Username or email”
- add link for logging in with a backup code

## Testing
- ⚠️ `dotnet build` *(missing dotnet: command not found and failed to install)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1ef6acc83309a9bfb30ef10c6f3