### PR TITLE
Use MudButton ButtonType submit in login form

### DIFF
--- a/UCDASearches_Blazor/Components/Pages/Login.razor
+++ b/UCDASearches_Blazor/Components/Pages/Login.razor
@@ -23,7 +23,7 @@
                               Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Badge" Required="true" />
                 <MudTextField @bind-Value="model.Password" Label="Password" Variant="Variant.Outlined"
                               InputType="InputType.Password" Required="true" />
-                <MudButton Type="Submit" StartIcon="@Icons.Material.Filled.ArrowForward" Class="btn-primary" FullWidth="true">
+                <MudButton ButtonType="ButtonType.Submit" StartIcon="@Icons.Material.Filled.ArrowForward" Class="btn-primary" FullWidth="true">
                     Log in
                 </MudButton>
             </MudStack>


### PR DESCRIPTION
## Summary
- fix login form submission by replacing deprecated Type with ButtonType.Submit

## Testing
- `dotnet build UCDASearches_Blazor/UCDASearches_Blazor.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae083bada48330b20d53f6aeae429c